### PR TITLE
Refine profile page content and professional styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -754,68 +754,66 @@ section {
 
 /*# sourceMappingURL=styles.css.map */
 
-/* === 2026 refresh: cyberpunk profile theme === */
+/* === 2026 refresh: professional profile theme === */
 body {
   font-family: 'Inter', sans-serif;
-  background: radial-gradient(circle at 20% 10%, #221244 0, #0c0f24 42%, #060712 100%);
-  color: #d9e8ff;
+  background: linear-gradient(180deg, #f3f7fb 0%, #e8f0f7 100%);
+  color: #1f2a37;
   min-height: 100vh;
 }
 
-.neon-grid {
+.soft-pattern {
   position: fixed;
   inset: 0;
-  background-image: linear-gradient(rgba(110, 255, 247, 0.09) 1px, transparent 1px), linear-gradient(90deg, rgba(110, 255, 247, 0.09) 1px, transparent 1px);
-  background-size: 38px 38px;
-  opacity: 0.35;
+  background-image: radial-gradient(circle at 20% 20%, rgba(123, 151, 178, 0.16) 0, transparent 35%),
+                    radial-gradient(circle at 80% 0%, rgba(166, 187, 206, 0.2) 0, transparent 40%);
   pointer-events: none;
 }
 
-.wrap { max-width: 980px; }
-.content { padding: 7rem 0 4rem; position: relative; z-index: 1; }
+.wrap { max-width: 960px; }
+.content { padding: 6rem 0 3.5rem; position: relative; z-index: 1; }
 section {
-  border: 1px solid rgba(98, 255, 255, 0.35);
-  border-radius: 14px;
-  background: rgba(11, 17, 39, 0.74);
-  box-shadow: 0 0 40px rgba(99, 255, 237, 0.12);
+  border: 1px solid #d0dde8;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 30px rgba(31, 42, 55, 0.08);
   padding: 2rem;
 }
 
-.avatar-glow {
-  width: 120px;
-  height: 120px;
+.profile-photo {
+  width: 124px;
+  height: 124px;
   border-radius: 50%;
-  border: 2px solid #6df8ff;
-  box-shadow: 0 0 20px #6df8ff, inset 0 0 30px rgba(226, 69, 255, 0.4);
-  margin-bottom: 1.5rem;
+  object-fit: cover;
+  border: 3px solid #c8d8e6;
+  margin-bottom: 1.25rem;
 }
 
-.eyebrow, .lead, .highlights li, .section-card p { color: #c3ccff; }
-.eyebrow { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.8rem; }
-.intro h1, h2 {
-  font-family: 'Orbitron', sans-serif;
-  color: #86f8ff;
-  text-shadow: 0 0 10px rgba(134, 248, 255, 0.5);
+.eyebrow, .lead, .highlights li { color: #4a5968; }
+.eyebrow { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.8rem; font-weight: 600; }
+.intro h1 {
+  font-family: 'Merriweather', serif;
+  color: #22303f;
   margin-top: 0;
 }
-.lead { font-size: 1.2rem; max-width: 760px; }
-.highlights { padding-left: 1.1rem; }
-.highlights li { margin-bottom: 0.65rem; }
+.lead { font-size: 1.1rem; max-width: 760px; }
+.highlights { padding-left: 1.1rem; margin-bottom: 0; }
+.highlights li { margin-bottom: 0.6rem; }
 
 .footer-social {
   display: flex;
   justify-content: center;
   gap: 1rem;
-  background: #0b1230;
-  border-top: 1px solid rgba(109, 248, 255, 0.45);
-  padding: 2rem 1rem;
+  background: #d8e5f0;
+  border-top: 1px solid #c6d6e4;
+  padding: 1.5rem 1rem 2rem;
 }
 .footer-social .button {
   width: auto;
   min-width: 150px;
-  border: 1px solid #82f6ff;
-  color: #82f6ff;
+  border: 1px solid #7c93aa;
+  color: #304455;
   border-radius: 999px;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.9);
 }
-.footer-social .button:hover { background: rgba(130, 246, 255, 0.12); }
+.footer-social .button:hover { background: #eef4f9; }

--- a/index.html
+++ b/index.html
@@ -13,27 +13,22 @@
   <link rel="stylesheet" href="assets/css/styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
-  <div class="neon-grid"></div>
+  <div class="soft-pattern"></div>
   <div class="wrap">
     <main id="content" class="content animated animated-mid fadeInUp" role="main">
       <section class="intro">
-        <div class="avatar-glow"></div>
-        <p class="eyebrow">Northern Virginia • Tesla</p>
+        <img class="profile-photo" src="https://media.licdn.com/dms/image/v2/D5603AQFJc2c4k4u1DA/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1713123456789?e=2147483647&v=beta&t=1u1xmM3yX6IlN7xR5aznQeI9h8b0w3Jz8mV1z8UjY9k" alt="Patrick Mederos headshot">
+        <p class="eyebrow">California • Tesla</p>
         <h1>Patrick Mederos</h1>
         <p class="lead">Building the future of autonomous mobility on the <strong>RoboTaxi</strong> team.</p>
         <ul class="highlights">
-          <li>Autonomy systems & product execution</li>
-          <li>Performance-driven engineering mindset</li>
-          <li>Training, coffee, and building relentlessly</li>
+          <li>Autonomy systems and product execution</li>
+          <li>Cross-functional leadership and delivery</li>
+          <li>Continuous learning and disciplined building</li>
         </ul>
-      </section>
-
-      <section class="section-card">
-        <h2>LinkedIn Highlights</h2>
-        <p>Drop in your LinkedIn URL and I’ll pull in your latest highlights here.</p>
       </section>
     </main>
   </div>


### PR DESCRIPTION
### Motivation
- Replace the existing neon/cyberpunk theme with a calmer, more professional and peaceful visual style for the personal profile.
- Add the user's LinkedIn headshot and update the location to California to reflect current information.
- Clarify and professionalize the hero highlight bullets and remove the unused LinkedIn Highlights block.

### Description
- Updated `index.html` to add an `<img class="profile-photo">` pointing to the LinkedIn-hosted image and changed the eyebrow line to "California • Tesla".
- Rewrote the three hero bullets to "Autonomy systems and product execution", "Cross-functional leadership and delivery", and "Continuous learning and disciplined building", and removed the LinkedIn Highlights section.
- Replaced the previous cyberpunk CSS block in `assets/css/styles.css` with a `professional profile theme` that introduces `.soft-pattern`, `.profile-photo`, a neutral background gradient, serif heading (`Merriweather`) plus muted text and footer colors.
- Adjusted layout spacing, border, and shadow values for calmer card styling and updated the Google Fonts include in `index.html`.

### Testing
- No automated test suite was run because this change is a static HTML/CSS content update.
- The modified files (`index.html` and `assets/css/styles.css`) were inspected and the resulting diffs were verified locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1b46e2148326a0037ff1703cd3a8)