### PR TITLE
Add Recognition section (curated, anonymized peer quotes)

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,51 @@
 
   <hr class="divider">
 
+  <!-- RECOGNITION -->
+  <section class="block" id="recognition">
+    <div class="container narrow">
+      <div class="section-head reveal">
+        <span class="eyebrow">Recognition</span>
+        <h2>What teammates say.</h2>
+      </div>
+      <div class="quotes reveal">
+        <div class="quote-card">
+          <div class="tag">Leads with purpose</div>
+          <blockquote>"The best instructor I've had in years. You always think about what's best for the company, but you never leave behind the people who put in the effort."</blockquote>
+          <cite>— Sebastian H., Tesla</cite>
+        </div>
+        <div class="quote-card">
+          <div class="tag">Robotaxi operations</div>
+          <blockquote>"The Robotaxi team needed support and Patrick stepped up — jumped in with both feet, cleaned up the process operationally, and identified key misses. Excited to see his continued impact and growth."</blockquote>
+          <cite>— David S., Tesla</cite>
+        </div>
+        <div class="quote-card">
+          <div class="tag">Future leader</div>
+          <blockquote>"Always willing to support other service centers — a true team player who cares for others. I foresee him taking on a leadership/management role."</blockquote>
+          <cite>— Rovinn S., Tesla</cite>
+        </div>
+        <div class="quote-card">
+          <div class="tag">Collaborative</div>
+          <blockquote>"Truly appreciate the positive impact you're having on Robotaxi operations. Your ability to collaborate and share knowledge swiftly across teams is admirable."</blockquote>
+          <cite>— Greg V., Tesla</cite>
+        </div>
+        <div class="quote-card">
+          <div class="tag">Driven</div>
+          <blockquote>"Someone you'd want on your team. A get-it-done mindset who delivers — and consistently puts the associates, the customers, and the business ahead of himself."</blockquote>
+          <cite>— Ventura D., Tesla</cite>
+        </div>
+        <div class="quote-card">
+          <div class="tag">Dependable</div>
+          <blockquote>"An excellent advisor who can be counted on for big things when they're needed most — a powerhouse who made a huge impact supporting teams across regions."</blockquote>
+          <cite>— Andy S., Tesla</cite>
+        </div>
+      </div>
+      <p class="recognition-note reveal">30+ peer recognitions across 6 years at Tesla.</p>
+    </div>
+  </section>
+
+  <hr class="divider">
+
   <!-- SKILLS + LANGUAGES -->
   <section class="block">
     <div class="container narrow">

--- a/styles.css
+++ b/styles.css
@@ -166,6 +166,15 @@ footer .sub { color: var(--muted); margin: 1rem auto 0; max-width: 46ch; }
 .foot-links a:hover { background: var(--accent); border-color: var(--accent); color: #fff; transform: translateY(-2px); }
 .foot-meta { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--line); font-size: 0.82rem; color: var(--muted); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 0.5rem; }
 
+/* ---------- Recognition / quotes ---------- */
+.quotes { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.1rem; text-align: left; }
+@media (max-width: 720px) { .quotes { grid-template-columns: 1fr; } }
+.quote-card { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius); padding: 1.5rem 1.6rem; display: flex; flex-direction: column; }
+.quote-card .tag { font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-deep); }
+.quote-card blockquote { font-size: 0.98rem; line-height: 1.62; color: var(--ink-soft); margin: 0.7rem 0 1rem; }
+.quote-card cite { font-style: normal; font-size: 0.82rem; color: var(--muted); font-weight: 600; margin-top: auto; }
+.recognition-note { text-align: center; color: var(--muted); font-size: 0.9rem; margin-top: 1.5rem; }
+
 /* ---------- Reveal animation ---------- */
 .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
 .reveal.in { opacity: 1; transform: none; }


### PR DESCRIPTION
Follow-up to #6 (the redesign). Adds a **Recognition** section to the page.

- 6 curated peer recognitions (from 30+), scrubbed of internal specifics (codenames, internal metrics, program names)
- Attributed first name + last initial (Patrick consented)
- Aggregate "30+ peer recognitions across 6 years at Tesla" proof line

🤖 Generated with [Claude Code](https://claude.com/claude-code)