### PR TITLE
Auto dark mode + footer easter egg (Nessie × Squirtle)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
   <title>Patrick Mederos — Service Operations &amp; Customer Experience</title>
   <meta name="description" content="Patrick Mederos — service operations and customer experience leader. The first person at Tesla to lead operations for the Robotaxi fleet.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#FFFFFF">
+  <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#14161B" media="(prefers-color-scheme: dark)">
 
   <meta property="og:type" content="profile">
   <meta property="og:title" content="Patrick Mederos — Service Operations &amp; Customer Experience">
@@ -338,6 +339,10 @@
           <span>© <span id="year"></span> Patrick Mederos</span>
           <span>San Jose, California</span>
         </div>
+        <div class="easter-egg" aria-hidden="true" title="just hangin'">
+          <span class="sprite sprite-nessie" id="sprite-nessie"></span>
+          <span class="sprite sprite-squirtle" id="sprite-squirtle"></span>
+        </div>
       </div>
     </div>
   </footer>
@@ -363,6 +368,67 @@
   } else {
     els.forEach(function (el) { el.classList.add('in'); });
   }
+
+  // Easter egg: pixel buddies — Nessie (Apex) × Squirtle
+  (function () {
+    function spriteSVG(grid, pal, px) {
+      var h = grid.length, w = 0, x, y, f, rects = '';
+      for (y = 0; y < h; y++) { if (grid[y].length > w) w = grid[y].length; }
+      for (y = 0; y < h; y++) {
+        for (x = 0; x < grid[y].length; x++) {
+          f = pal[grid[y][x]];
+          if (f) rects += '<rect x="' + x + '" y="' + y + '" width="1" height="1" fill="' + f + '"/>';
+        }
+      }
+      return '<svg width="' + (w * px) + '" height="' + (h * px) + '" viewBox="0 0 ' + w + ' ' + h +
+             '" shape-rendering="crispEdges" xmlns="http://www.w3.org/2000/svg">' + rects + '</svg>';
+    }
+
+    var squirtlePal = { O:'#173a52', b:'#83c9ec', w:'#ffffff', k:'#16242e', S:'#9a5a1c', c:'#f6dca8', p:'#f29bb0' };
+    var squirtle = [
+      ".....OOOOOO.....",
+      "...OObbbbbbOO...",
+      "..ObbbbbbbbbbO..",
+      ".ObbbbbbbbbbbbO.",
+      ".ObwwbbbbbbwwbO.",
+      ".ObwkbbbbbbkwbO.",
+      ".ObbbbbbbbbbbbO.",
+      ".ObbppbbbbppbbO.",
+      "..ObbbbbbbbbbO..",
+      "...OSSSSSSSSO...",
+      "..OSccccccccSO..",
+      ".bOSccccccccSOb.",
+      "..OSccccccccSO..",
+      "...OSSSSSSSSO...",
+      "...Obb....bbO...",
+      "....OO....OO...."
+    ];
+
+    var nessiePal = { O:'#0e4d49', t:'#34c7be', e:'#a9efe7', k:'#16242e' };
+    var nessie = [
+      "......OOO.......",
+      ".....OtttO......",
+      ".....OtttO......",
+      ".....OktkO......",
+      ".....OtttO......",
+      "......OtO.......",
+      "......OtO.......",
+      "......OtO.......",
+      ".....OtttO......",
+      "...OOtttttOO....",
+      "..OttttttttO....",
+      ".OtteeeeeettO...",
+      ".OteeeeeeeetO...",
+      ".OtteeeeeettO...",
+      "..OttttttttO....",
+      "....OO..OO......"
+    ];
+
+    var n = document.getElementById('sprite-nessie');
+    var s = document.getElementById('sprite-squirtle');
+    if (n) n.innerHTML = spriteSVG(nessie, nessiePal, 4);
+    if (s) s.innerHTML = spriteSVG(squirtle, squirtlePal, 4);
+  })();
 </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -180,3 +180,41 @@ footer .sub { color: var(--muted); margin: 1rem auto 0; max-width: 46ch; }
 .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
 .reveal.in { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; transition: none; } html { scroll-behavior: auto; } }
+
+/* ---------- Auto dark mode (follows system) ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:      #14161B;
+    --surface:    #1C1F26;
+    --ink:        #F3F5F8;
+    --ink-soft:   #C6CAD2;
+    --muted:      #888E99;
+    --line:       #2A2E37;
+    --line-soft:  #23262E;
+    --accent:     #FF4B50;   /* brighter red for dark */
+    --accent-deep:#FF8E8A;   /* light red for text/links on dark */
+    --accent-tint:rgba(255,75,80,0.18);
+    --cta:        #5A78FF;
+    --cta-hover:  #7C93FF;
+  }
+  header { background: rgba(20,22,27,0.8); }
+  body::before { background: radial-gradient(80% 50% at 50% -10%, rgba(255,255,255,0.05), transparent 60%); }
+  .avatar { box-shadow: 0 0 0 5px var(--paper), 0 0 0 6px var(--line), 0 16px 40px rgba(0,0,0,0.5); }
+  .btn-primary:hover { box-shadow: 0 8px 24px rgba(90,120,255,0.35); }
+}
+
+/* ---------- Easter egg: Nessie × Squirtle ---------- */
+.easter-egg { display: flex; align-items: flex-end; justify-content: center; gap: 12px; margin-top: 2.6rem; min-height: 64px; }
+.sprite { display: inline-block; line-height: 0; filter: drop-shadow(0 4px 6px rgba(0,0,0,0.18)); }
+.sprite svg { display: block; }
+.sprite-nessie { transform-origin: bottom center; animation: nessieBob 3.4s ease-in-out infinite; }
+.sprite-squirtle { transform-origin: bottom center; animation: squirtleBob 2.7s ease-in-out infinite; }
+@keyframes nessieBob {
+  0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+  50%      { transform: translateY(-5px) rotate(1.5deg); }
+}
+@keyframes squirtleBob {
+  0%, 100% { transform: translateY(0) rotate(1.5deg); }
+  50%      { transform: translateY(-3px) rotate(-2deg); }
+}
+@media (prefers-reduced-motion: reduce) { .sprite-nessie, .sprite-squirtle { animation: none; } }


### PR DESCRIPTION
Two fun additions:

## 🌗 Auto light/dark mode
Follows the visitor's system setting via `prefers-color-scheme` — dark palette overrides for background, text, accents, and the blue CTA, plus a dark `theme-color`. No toggle, no JS; pure CSS.

## 🦕🐢 Footer easter egg
A hidden pair of hand-pixeled SVG buddies chilling at the bottom of the footer — **Nessie** (Apex Legends) and **Squirtle** — gently bob-animated for cuteness. Respects `prefers-reduced-motion` (animation off for those who opt out). Rendered from tiny string grids, no image assets.

## Test plan
- [ ] Toggle system dark mode → site flips automatically
- [ ] Scroll to footer → two animated pixel buddies
- [ ] Reduced-motion on → buddies hold still

🤖 Generated with [Claude Code](https://claude.com/claude-code)