### PR TITLE
Update hero, stats, Robotaxi role copy, and footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       <p class="eyebrow">San Jose, California</p>
       <h1>Patrick Mederos</h1>
       <p class="role">Service Operations &amp; Customer Experience</p>
-      <p class="lead">The first person at Tesla to lead operations for the <strong>Robotaxi</strong> fleet — building the human systems that keep autonomous vehicles on the road. A decade-plus of turning service into a competitive advantage.</p>
+      <p class="lead">Among the first on Tesla's <strong>Robotaxi</strong> team — and the first Operations Advisor in the program — helping define what great autonomous vehicle service looks like as the fleet expands nationwide.</p>
       <div class="cta-row">
         <a class="btn btn-primary" href="mailto:patrickvmederos@gmail.com">Get in touch</a>
         <a class="btn btn-ghost" href="https://www.linkedin.com/in/patrickmederos" target="_blank" rel="noopener">LinkedIn ↗</a>
@@ -54,10 +54,10 @@
   <!-- STATS -->
   <div class="container narrow">
     <div class="stats reveal">
-      <div class="stat"><div class="num">1<span>st</span></div><div class="lbl">At Tesla to hold the Robotaxi Operations role</div></div>
+      <div class="stat"><div class="num">6<span>+</span></div><div class="lbl">Years at Tesla</div></div>
+      <div class="stat"><div class="num">10<span>K+</span></div><div class="lbl">Customers helped throughout my career</div></div>
       <div class="stat"><div class="num">Top <span>5%</span></div><div class="lbl">CSAT across Tesla's global service network</div></div>
-      <div class="stat"><div class="num">250<span>+</span></div><div class="lbl">Service appointments QA'd per day</div></div>
-      <div class="stat"><div class="num">3</div><div class="lbl">Languages — English, Spanish, Portuguese</div></div>
+      <div class="stat"><div class="num">$5<span>M+</span></div><div class="lbl">In service sales as an advisor</div></div>
     </div>
   </div>
 
@@ -70,7 +70,7 @@
       </div>
       <div class="prose reveal">
         <p>I've spent more than a decade making service operations excellent — in dealerships, at a mobile-mechanic startup, and across Tesla's service network. My work lives where customer experience meets operational rigor: keeping fleets moving, resolving issues before they escalate, and building the workflows that let teams scale.</p>
-        <p>Today I'm pioneering operations for Tesla's <strong>Robotaxi</strong> fleet — the first person in the company to hold the role. I helped define it from scratch: the playbooks, the tooling, even the job description for the people who come next. Recently certified in <strong>Artificial Intelligence</strong>, I'm focused on where autonomy and human-centered service meet.</p>
+        <p>Today I'm Tesla's first <strong>Robotaxi Operations Advisor</strong> — a role I helped define from scratch. Beyond keeping the Bay Area fleet running, I'm helping shape how the program scales: partnering with teams in Texas, Florida, and Las Vegas to train advisors and build the operational playbook for each new market. Recently certified in <strong>Artificial Intelligence</strong>, I'm focused on where autonomy and human-centered service meet.</p>
       </div>
     </div>
   </section>
@@ -96,9 +96,9 @@
           <div class="rtitle">Robotaxi Operations Advisor <span class="first">First in role</span></div>
           <div class="rmeta">Dec 2025 – Present · San Francisco Bay Area</div>
           <ul>
-            <li>Built the position from the ground up — workflows, playbooks, tooling, and the job description for future hires.</li>
-            <li>Keep the fleet on the road by coordinating repairs across service centers, body shops, tow vendors, and Mobile Service.</li>
-            <li>Triage and track fleet issues in internal systems (SCA, JIRA, Garage, Beacon) to restore out-of-service vehicles fast.</li>
+            <li>Tesla's first Robotaxi Operations Advisor — built the role from scratch, creating the playbooks, workflows, tooling, and job description that define the position going forward.</li>
+            <li>Keep the fleet on the road by coordinating repairs across service centers, body shops, tow vendors, and Mobile Service; triage and track issues in SCA, JIRA, Garage, and Beacon.</li>
+            <li>Serving as a model for expansion — actively partnering with teams in Texas, Florida, and Las Vegas to train advisors and share operational best practices as those markets come online.</li>
             <li>Analyze rider-feedback trends with Programs &amp; Engineering, and own lost &amp; found end-to-end.</li>
           </ul>
         </div>
@@ -286,8 +286,6 @@
         <div class="foot-links">
           <a href="mailto:patrickvmederos@gmail.com">Email</a>
           <a href="https://www.linkedin.com/in/patrickmederos" target="_blank" rel="noopener">LinkedIn ↗</a>
-          <a href="https://www.instagram.com/patrickmederos/" target="_blank" rel="noopener">Instagram ↗</a>
-          <a href="https://www.youtube.com/channel/UCu3F_Hs3VZOnUqtbaGeM8wA" target="_blank" rel="noopener">YouTube ↗</a>
         </div>
         <div class="foot-meta">
           <span>© <span id="year"></span> Patrick Mederos</span>


### PR DESCRIPTION
- Hero tagline: reframe as first Robotaxi Operations Advisor rather than 'first person to lead operations', feels more accurate and punchy
- Stats: replace placeholder numbers with 6+ years at Tesla, 10K+ customers helped, top 5% CSAT, and $5M+ in service sales
- Robotaxi role bullets: add market-expansion context (TX, FL, Las Vegas training) and reinforce 'first in role' framing
- About section: same market-expansion and first-advisor angle
- Footer: remove Instagram and YouTube links

https://claude.ai/code/session_01J2pj6EcSx8nHTGyJzmM7zg